### PR TITLE
Change makefile restart-mattermost behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ restart:
 	@make check-mattermost
 
 restart-mattermost:
-	@docker restart cs-repro-mattermost
+	@echo "Stopping Mattermost container"
+	@docker stop cs-repro-mattermost
+	@wait
+	@echo "Starting Mattermost container"
+	@docker start cs-repro-mattermost
 	@make check-mattermost
 
 reset:


### PR DESCRIPTION
Switching to a `docker stop` and `docker start` instead of `docker restart`.  In testing it appears restart breaks Mattermost container's ability to utilize the saml certificate.  