### PR TITLE
change containers owner for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	
 logs:
 	@echo "Following logs..."
-	@docker-compose logs --follow
+	@docker compose logs --follow
 	@echo "Done"
 
 setup-mattermost:
@@ -23,17 +23,17 @@ echo-logins:
 start: 
 	@echo "Starting..."
 	@make restore-keycloak
-	@docker-compose up -d
+	@docker compose up -d
 	@make setup-mattermost
 	@make echo-logins
 	
 stop:
 	@echo "Stopping..."
-	@docker-compose stop
+	@docker compose stop
 	@echo "Done"
 
 restart:
-	@docker-compose restart
+	@docker compose restart
 	@make check-mattermost
 
 restart-mattermost:
@@ -55,12 +55,12 @@ downgrade:
 	@docker stop cs-repro-postgres || true && docker rm cs-repro-postgres || true
 	rm -rf ./volumes/mattermost
 	rm -rf ./volumes/db
-	docker-compose up -d
+	docker compose up -d
 	@make setup-mattermost
 
 delete-dockerfiles:
 	@echo "Deleting data..."
-	@docker-compose rm
+	@docker compose rm
 	@rm -rf ./volumes
 	@echo "Done"
 
@@ -68,6 +68,11 @@ delete-data: stop delete-dockerfiles
 
 nuke: 
 	@echo "Nuking Docker..."
-	@docker-compose down --rmi all --volumes --remove-orphans
+	@docker compose down --volumes --remove-orphans
+	@make delete-data
+
+nuke-img: 
+	@echo "Nuking Docker along with all the images..."
+	# @docker compose down --rmi all --volumes --remove-orphans
 	@make delete-data
 

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,6 @@ nuke:
 
 nuke-img: 
 	@echo "Nuking Docker along with all the images..."
-	# @docker compose down --rmi all --volumes --remove-orphans
+	@docker compose down --rmi all --volumes --remove-orphans
 	@make delete-data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - "10389:10389"
       - "10636:10636"
   prometheus:
+    user: root
     container_name: cs-repro-prometheus
     image: prom/prometheus:latest
     restart: unless-stopped
@@ -70,6 +71,7 @@ services:
       - ./files/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./volumes/prometheus:/prometheus
   grafana:
+    user: root
     container_name: cs-repro-grafana
     image: grafana/grafana:7.5.7
     ports:
@@ -84,6 +86,7 @@ services:
       - ./files/grafana/provisioning:/etc/grafana/provisioning
       - ./volumes/grafana:/var/lib/grafana
   mattermost:
+    user: root
     platform: linux/amd64
     container_name: cs-repro-mattermost
     depends_on:


### PR DESCRIPTION
* Few containers run with non-root users, but are dependent on the volumes,files folders created in the repo. So, those containers give "permission denied" access on linux.

* Updated the `docker-compose` to `docker compose`. _No hyphen_

* Updated the `make nuke` option to keep the `images`. And created another explicit option to remove them as well.