### PR TITLE
Make nuke not remove images (and add an option to do it)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ delete-data: stop delete-dockerfiles
 
 nuke: 
 	@echo "Nuking Docker..."
-	@docker-compose down --rmi all --volumes --remove-orphans
+	@docker-compose down --volumes --remove-orphans
 	@make delete-data
 
+nuke-rmi: 
+	@echo "Nuking Docker with images..."
+	@docker-compose down --rmi all --volumes --remove-orphans
+	@make delete-data

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ This clears all data from the volumes and stops Mattermost.
 
 Destroys everything (Except your life). 
 
+### `make nuke-rmi`
+
+Destroys everything, and removes the docker images used. 
+
 ## Accounts
 
 | Username  | Password  | Keycloak Role | Mattermost Role | Can use LDAP? | Can use SAML? |


### PR DESCRIPTION
I find that removing the images with `nuke` is quite annoying, so I had the idea of removing this part of nuke and adding a `nuke-rmi` that does both.

What do you think?