### PR TITLE
Update PictureAttribute in defaultConfig.json

### DIFF
--- a/files/mattermost/defaultConfig.json
+++ b/files/mattermost/defaultConfig.json
@@ -62,7 +62,7 @@
       "IdAttribute": "uid",
       "PositionAttribute": "",
       "LoginIdAttribute": "uid",
-      "PictureAttribute": "",
+      "PictureAttribute": "jpegPhoto",
       "SyncIntervalMinutes": 60,
       "SkipCertificateVerification": false,
       "PublicCertificateFile": "",


### PR DESCRIPTION
using the jpegPhoto attribute from the openldap test repo. the profile pics are only pulled during user login and not during ldap sync