### PR TITLE
Refactor Makefile start command to use 'run' instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,16 @@ restore-keycloak:
 echo-logins:
 	@./scripts/general.sh logins
 
-start: 
+run: 
 	@echo "Starting..."
 	@make restore-keycloak
 	@docker-compose up -d
 	@make setup-mattermost
 	@make echo-logins
-	
+
+start:
+	@make run
+
 stop:
 	@echo "Stopping..."
 	@docker-compose stop


### PR DESCRIPTION
changes make run to be the default command to run the whole setup, which is more in line with makefile naming conventions.

also added an alias for make start for people who prefer that.