### PR TITLE
Update Mattermost image version to 9.6 and remove obsolute version directive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   # mysql:
   #   container_name: cs-repro-mysql
@@ -131,7 +129,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    image: mattermost/mattermost-enterprise-edition:release-9.0
+    image: mattermost/mattermost-enterprise-edition:release-9.6
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
The version directive at the top of the docker-compose file is no longer needed so we can remove it.


Also updating the mattermost image version while we're at it